### PR TITLE
Rename cluster to confluent_cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,27 +11,27 @@ Our need to export this data led us down the path of kafka-exporter and it's for
 ```bash
 # HELP kafka_broker_info Broker information - the value is arbitrary (labels hold info).
 # TYPE kafka_broker_info gauge
-kafka_broker_info{addr="b0-pkc-xxxxxx.europe-west1.gcp.confluent.cloud:9092",cluster="my-cluster",id="0",rack="0"} 1
+kafka_broker_info{addr="b0-pkc-xxxxxx.europe-west1.gcp.confluent.cloud:9092",confluent_cluster="my-cluster",id="0",rack="0"} 1
 ...
 # HELP kafka_consumer_group_members The number of members in a consumer group.
 # TYPE kafka_consumer_group_members gauge
-kafka_consumer_group_members{cluster="my-cluster",name="my-consumer-group",protocol="",protocol_type="consumer",state="Empty"} 0
+kafka_consumer_group_members{confluent_cluster="my-cluster",name="my-consumer-group",protocol="",protocol_type="consumer",state="Empty"} 0
 ...
 # HELP kafka_consumer_group_offsets The offset of a consumer group in a topic.
 # TYPE kafka_consumer_group_offsets gauge
-kafka_consumer_group_offsets{cluster="my-cluster",name="my-consumer-group",partition="0",topic="my-super-topic"} 15648
+kafka_consumer_group_offsets{confluent_cluster="my-cluster",name="my-consumer-group",partition="0",topic="my-super-topic"} 15648
 ...
 # HELP kafka_topic_info Topic information - the value is arbitrary (labels hold info).
 # TYPE kafka_topic_info gauge
-kafka_topic_info{cluster="my-cluster",internal="false",name="my-super-topic",partitions="1"} 1
+kafka_topic_info{confluent_cluster="my-cluster",internal="false",name="my-super-topic",partitions="1"} 1
 ...
 # HELP kafka_topic_parititions Number of partitions in a topic
 # TYPE kafka_topic_parititions gauge
-kafka_topic_parititions{cluster="my-cluster",topic="my-super-topic"} 1
+kafka_topic_parititions{confluent_cluster="my-cluster",topic="my-super-topic"} 1
 ...
 # HELP kafka_topic_partition_info Topic partition information - the value is arbitrary (labels hold info).
 # TYPE kafka_topic_partition_info gauge
-kafka_topic_partition_info{cluster="my-cluster",leader="1",offline_replicas="0",partition="0",replicas="3",topic="my-super-topic"} 1
+kafka_topic_partition_info{confluent_cluster="my-cluster",leader="1",offline_replicas="0",partition="0",replicas="3",topic="my-super-topic"} 1
 ...
 ```
 

--- a/internal/collector.go
+++ b/internal/collector.go
@@ -52,10 +52,10 @@ func collect() error {
 	brokerMetrics.Reset()
 	for _, broker := range brokers {
 		brokerMetrics.With(prometheus.Labels{
-			"cluster": clusterLabel,
-			"id":      fmt.Sprintf("%d", broker.ID()),
-			"addr":    broker.Addr(),
-			"rack":    broker.Rack(),
+			"confluent_cluster": clusterLabel,
+			"id":                fmt.Sprintf("%d", broker.ID()),
+			"addr":              broker.Addr(),
+			"rack":              broker.Rack(),
 		}).Set(1)
 	}
 
@@ -81,26 +81,26 @@ func collect() error {
 	topicPartitionDetailMetrics.Reset()
 	for _, topic := range topicsMetadata {
 		topicMetrics.With(prometheus.Labels{
-			"cluster":    clusterLabel,
-			"name":       topic.Name,
-			"partitions": strconv.Itoa(len(topic.Partitions)),
-			"internal":   strconv.FormatBool(topic.IsInternal),
+			"confluent_cluster": clusterLabel,
+			"name":              topic.Name,
+			"partitions":        strconv.Itoa(len(topic.Partitions)),
+			"internal":          strconv.FormatBool(topic.IsInternal),
 		}).Set(1)
 
 		topicPartitionMetrics.With(prometheus.Labels{
-			"cluster": clusterLabel,
-			"topic":   topic.Name,
+			"confluent_cluster": clusterLabel,
+			"topic":             topic.Name,
 		}).Set(float64(len(topic.Partitions)))
 
 		for _, partition := range topic.Partitions {
 			topicPartitions[topic.Name] = append(topicPartitions[topic.Name], partition.ID)
 			topicPartitionDetailMetrics.With(prometheus.Labels{
-				"cluster":          clusterLabel,
-				"topic":            topic.Name,
-				"partition":        fmt.Sprintf("%d", partition.ID),
-				"leader":           fmt.Sprintf("%d", partition.Leader),
-				"replicas":         strconv.Itoa(len(partition.Replicas)),
-				"offline_replicas": strconv.Itoa(len(partition.OfflineReplicas)),
+				"confluent_cluster": clusterLabel,
+				"topic":             topic.Name,
+				"partition":         fmt.Sprintf("%d", partition.ID),
+				"leader":            fmt.Sprintf("%d", partition.Leader),
+				"replicas":          strconv.Itoa(len(partition.Replicas)),
+				"offline_replicas":  strconv.Itoa(len(partition.OfflineReplicas)),
 			}).Set(1)
 		}
 	}
@@ -124,11 +124,11 @@ func collect() error {
 	consumerGroupOffsetMetrics.Reset()
 	for _, consumerGroupDescription := range groupDescriptions {
 		consumerGroupMembersMetrics.With(prometheus.Labels{
-			"cluster":       clusterLabel,
-			"name":          consumerGroupDescription.GroupId,
-			"state":         consumerGroupDescription.State,
-			"protocol":      consumerGroupDescription.Protocol,
-			"protocol_type": consumerGroupDescription.ProtocolType,
+			"confluent_cluster": clusterLabel,
+			"name":              consumerGroupDescription.GroupId,
+			"state":             consumerGroupDescription.State,
+			"protocol":          consumerGroupDescription.Protocol,
+			"protocol_type":     consumerGroupDescription.ProtocolType,
 		}).Set(float64(len(consumerGroupDescription.Members)))
 
 		o, err := clusterAdmin.ListConsumerGroupOffsets(consumerGroupDescription.GroupId, topicPartitions)
@@ -141,10 +141,10 @@ func collect() error {
 				// only track metrics for block offsets that aren't `-1` - those are not subscribed to the topic
 				if block.Offset >= 0 {
 					consumerGroupOffsetMetrics.With(prometheus.Labels{
-						"cluster":   clusterLabel,
-						"name":      consumerGroupDescription.GroupId,
-						"topic":     topic,
-						"partition": fmt.Sprintf("%d", i),
+						"confluent_cluster": clusterLabel,
+						"name":              consumerGroupDescription.GroupId,
+						"topic":             topic,
+						"partition":         fmt.Sprintf("%d", i),
 					}).Set(float64(block.Offset))
 				}
 			}

--- a/internal/metrics.go
+++ b/internal/metrics.go
@@ -16,7 +16,7 @@ var (
 			Name:      "info",
 			Help:      "Topic information - the value is arbitrary (labels hold info).",
 		},
-		[]string{"cluster", "name", "partitions", "internal"},
+		[]string{"confluent_cluster", "name", "partitions", "internal"},
 	)
 	topicPartitionMetrics = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -25,7 +25,7 @@ var (
 			Name:      "parititions",
 			Help:      "Number of partitions in a topic",
 		},
-		[]string{"cluster", "topic"},
+		[]string{"confluent_cluster", "topic"},
 	)
 	topicPartitionDetailMetrics = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -34,7 +34,7 @@ var (
 			Name:      "partition_info",
 			Help:      "Topic partition information - the value is arbitrary (labels hold info).",
 		},
-		[]string{"cluster", "topic", "partition", "leader", "replicas", "offline_replicas"},
+		[]string{"confluent_cluster", "topic", "partition", "leader", "replicas", "offline_replicas"},
 	)
 	consumerGroupMembersMetrics = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -43,7 +43,7 @@ var (
 			Name:      "members",
 			Help:      "The number of members in a consumer group.",
 		},
-		[]string{"cluster", "name", "state", "protocol", "protocol_type"},
+		[]string{"confluent_cluster", "name", "state", "protocol", "protocol_type"},
 	)
 	consumerGroupOffsetMetrics = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -52,7 +52,7 @@ var (
 			Name:      "offsets",
 			Help:      "The offset of a consumer group in a topic.",
 		},
-		[]string{"cluster", "name", "topic", "partition"},
+		[]string{"confluent_cluster", "name", "topic", "partition"},
 	)
 	brokerMetrics = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -61,7 +61,7 @@ var (
 			Name:      "info",
 			Help:      "Broker information - the value is arbitrary (labels hold info).",
 		},
-		[]string{"cluster", "id", "addr", "rack"},
+		[]string{"confluent_cluster", "id", "addr", "rack"},
 	)
 )
 


### PR DESCRIPTION
Commonly `cluster` is used in metrics to describe the cluster where the metrics were scraped from.

To avoid any overlap. this change make the cluster more explicitly the confluent cluster.